### PR TITLE
add AWS health check module

### DIFF
--- a/health_check/README.md
+++ b/health_check/README.md
@@ -1,0 +1,37 @@
+# AWS health check
+
+Creates an AWS Health Check and associated Cloudwatch Alarm.
+
+## Example
+
+```
+module "amc_ficus_health_check" {
+  source = "github.com/appsembler/tfmodules//health_check"
+  name = "AMC ficus"
+  fqdn = "studio.tahoe.appsembler.com"
+  path = "/heartbeat"
+  notify_action = "${aws_sns_topic.amc_pagerduty_topic.arn}"
+}
+```
+
+## Variables
+
+* `name` - name of the health check (required)
+* `fqdn` - hostname to check (required)
+* `path` - path to check. defaults to `/`. Ideally, set this to some
+  kind of smoketest or health check endpoint. `fqdn` and `path`
+  together specify the full URL to check (HTTPS-only).
+* `failure_threshold` - The number of consecutive health checks that
+  an endpoint must pass or fail before the alarm is
+  raised/cleared. Defaults to 3.
+* `request_internal` - number of seconds between checks. defaults to 30.
+* `regions` - list of regions to run the checks from. defaults to
+  `["us-east-1", "eu-west-1", "us-west-1"]`. This is probably fine for
+  most setups. If the check is for a customer with a large presence in
+  some other region, it might be worth adding one for them as well.
+* `notify_action` - ARN of an SNS topic that will be notified when
+  this check fails/recovers. required.
+
+## Outputs
+
+There are no outputs from this module.

--- a/health_check/main.tf
+++ b/health_check/main.tf
@@ -1,0 +1,33 @@
+resource "aws_route53_health_check" "check" {
+  fqdn = "${var.fqdn}"
+  port = 443
+  type = "HTTPS"
+  resource_path = "${var.path}"
+  failure_threshold = "${var.failure_threshold}"
+  request_interval = "${var.request_interval}"
+
+  regions = "${var.regions}"
+
+  tags {
+     Name = "tf-${var.name}-health-check"
+     Terraform = true
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm" {
+   alarm_name = "tf-${var.name}-health-check-status"
+   comparison_operator = "LessThanThreshold"
+   evaluation_periods = "1"
+   metric_name = "HealthCheckStatus"
+   namespace = "AWS/Route53"
+   period = "60"
+   threshold = "1"
+
+   alarm_actions = ["${var.notify_action}"]
+
+   statistic = "Minimum"
+   dimensions {
+     HealthCheckId = "${aws_route53_health_check.check.id}"
+   }
+   treat_missing_data = "missing"
+}

--- a/health_check/main.tf
+++ b/health_check/main.tf
@@ -24,6 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
    threshold = "1"
 
    alarm_actions = ["${var.notify_action}"]
+   ok_actions = ["${var.notify_action}"]
 
    statistic = "Minimum"
    dimensions {

--- a/health_check/variables.tf
+++ b/health_check/variables.tf
@@ -1,0 +1,22 @@
+variable name {}
+
+variable fqdn {}
+
+variable path {
+  default = "/"
+}
+
+variable failure_threshold {
+  default = "3"
+}
+
+variable request_interval {
+  default = "30"
+}
+
+variable regions {
+  default = ["us-east-1", "eu-west-1", "us-west-1"]
+}
+
+variable notify_action {
+}


### PR DESCRIPTION
Creates an AWS health check and associated Cloudwatch alarm.

I've been setting up AWS health checks to monitor our apps. I know we are able to do this with stackdriver as well but 1) I like the idea of having health checks come from a different provider (too easy to accidentally set up a firewall that blocks access to an app but allows stackdriver) and 2) terraform can fully configure this, and i can also make terraform talk to pagerduty, so this gets us one step closer to fully automating the entire setup.