### PR TITLE
add Pagerduty SNS topic+subscription

### DIFF
--- a/pagerduty_sns/README.md
+++ b/pagerduty_sns/README.md
@@ -1,0 +1,35 @@
+# Pagerduty SNS subscription
+
+Creates an SNS topic with a pagerduty subscription connected. Intended
+to be the target for a Cloudwatch alarm, etc.
+
+## Example
+
+```
+module "example_pagerduty_topic" {
+  name = "Example Topic"
+  pagerduty_integration_url = "https://events.pagerduty.com/.../enqueue"
+}
+output "topic_arn" {
+  value = "${module.example_pagerduty_topic.arn}"
+}
+```
+
+Running `terraform apply` results in output like:
+
+```
+topic_arn = "arn:..."
+```
+
+## Variables
+
+* `name` - name for the topic (required)
+* `pagerduty_integration_url` - URL of the pagerduty endpoint for your
+  integration (required). See the first part of
+  [this guide](https://www.pagerduty.com/docs/guides/aws-cloudwatch-integration-guide/)
+  for setting up the integration on the pagerduty side.
+
+## Outputs
+
+* `arn` - the ARN of the SNS topic. This is typically needed for
+  connecting it to an alarm.

--- a/pagerduty_sns/main.tf
+++ b/pagerduty_sns/main.tf
@@ -1,0 +1,10 @@
+resource "aws_sns_topic" "topic" {
+  name = "${var.name}"
+}
+
+resource "aws_sns_topic_subscription" "subscription" {
+  topic_arn = "${aws_sns_topic.topic.arn}"
+  protocol  = "https"
+  endpoint  = "${var.pagerduty_integration_url}"
+  endpoint_auto_confirms = true
+}

--- a/pagerduty_sns/outputs.tf
+++ b/pagerduty_sns/outputs.tf
@@ -1,0 +1,3 @@
+output "topic_arn" {
+  value = "${aws_sns_topic.topic.arn}"
+}

--- a/pagerduty_sns/variables.tf
+++ b/pagerduty_sns/variables.tf
@@ -1,0 +1,2 @@
+variable name {}
+variable pagerduty_integration_url {}


### PR DESCRIPTION
Makes an SNS topic and subscription that submits to a Pagerduty integration endpoint.