### PR TITLE
parameterize threshold and duration values for stackdriver alerts

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -14,6 +14,12 @@ project and can just put in the IDs as inputs for this module.
 module "stackdriver_alerts" {
   source = "github.com/appsembler/tfmodules//stackdriver?ref=stackdriver-0.1.0"
   gce_project = "appsembler-example-123"
+  
+  throttled_write_ops_threshold = 2
+  throttled_write_ops_duration = "1800s"
+  
+  cpu_high_threshold = 95
+  
   notification_channels = [
     "projects/appsembler-example-123/notificationChannels/123412341234",
     "projects/appsembler-example-123/notificationChannels/432143114312"
@@ -26,10 +32,42 @@ module "stackdriver_alerts" {
 * `gce_project` - project id of the GCP project (required)
 * `notification_channels` - list of notification channel ids.
 
+Each alert is parameterizable via threshold and duration
+variables. None are required (you just get the default values). The
+threshold is the value where the alert triggers at, duration is how
+long it has to stay over (or under) the threshold before the alert
+triggers.
+
+* `throttled_write_ops_threshold` - defaults to `1`
+* `throttled_write_ops_duration` - defaults to `900s` (15 minutes)
+* `disk_usage_threshold` - percentage of disk usage. defaults to `90`
+* `disk_usage_duration` - defaults to `3600s`
+* `disk_operations_threshold` - defaults to `4`
+* `disk_operations_duration` - defaults to `900s`
+* `cpu_high_threshold` - percentage CPU usage. This is the kind of
+  metric that tends to be very spiky. It's usually pretty normal for
+  CPU to spike to 100% for a while during a deploy or something. We
+  are interested in getting an alert when it's been high for a long
+  time, which is more likely to indicate something being stuck and
+  actually needing attention. So the CPU alerts are split into three
+  levels with decreasing thresholds and longer durations. defaults to `90`
+* `cpu_high_threshold` - defaults to `900s`
+* `cpu_medium_threshold` - defaults to `80`
+* `cpu_medium_duration` - defaults to `3600s`
+* `cpu_low_threshold` - defaults to `50`
+* `cpu_low_threshold` - defaults to `21600s` (6 hours)
+* `memory_threshold` - percentage memory usage. defaults to `90`.
+* `memory_duration` - defaults to `900s`
+* `disk_io_latency_threshold` - average latency on disk io. defaults
+   to `3`
+* `disk_io_latency_duration` - defaults to `900s`.
+
+
 ## Outputs
 
 This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-0.2.0` - parameterize threshold/duration for all alerts
 * `stackdriver-0.1.0` - initial version

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -8,9 +8,9 @@ resource "google_monitoring_alert_policy" "high_throttled_write_ops" {
 
     condition_threshold {
       filter          = "metric.type=\"compute.googleapis.com/instance/disk/throttled_write_ops_count\" resource.type=\"gce_instance\""
-      duration        = "900s"
+      duration        = "${var.throttled_write_ops_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 1
+      threshold_value = "${var.throttled_write_ops_threshold}"
 
       trigger {
         count = 1
@@ -43,7 +43,7 @@ resource "google_monitoring_alert_policy" "high_throttled_write_ops" {
 
 resource "google_monitoring_alert_policy" "disk_usage_90" {
   project      = "${var.gce_project}"
-  display_name = "Disk usage over 90%"
+  display_name = "Disk usage over ${var.disk_usage_threshold}%"
   combiner     = "OR"
 
   conditions {
@@ -51,9 +51,9 @@ resource "google_monitoring_alert_policy" "disk_usage_90" {
 
     condition_threshold {
       filter          = "metric.type=\"agent.googleapis.com/disk/percent_used\" resource.type=\"gce_instance\" metric.label.\"state\"=\"used\""
-      duration        = "3600s"
+      duration        = "${var.disk_usage_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 90
+      threshold_value = "${var.disk_usage_threshold}"
 
       trigger {
         count = 1
@@ -84,9 +84,9 @@ resource "google_monitoring_alert_policy" "high_disk_operations" {
 
     condition_threshold {
       filter          = "metric.type=\"agent.googleapis.com/disk/operation_count\" resource.type=\"gce_instance\""
-      duration        = "900s"
+      duration        = "${var.disk_operations_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 4
+      threshold_value = "${var.disk_operations_threshold}"
 
       trigger {
         count = 1
@@ -114,7 +114,7 @@ resource "google_monitoring_alert_policy" "high_disk_operations" {
 
 resource "google_monitoring_alert_policy" "cpu_90" {
   project      = "${var.gce_project}"
-  display_name = "CPU over 90%"
+  display_name = "CPU over ${var.cpu_high_threshold}%"
   combiner     = "OR"
 
   conditions {
@@ -122,9 +122,9 @@ resource "google_monitoring_alert_policy" "cpu_90" {
 
     condition_threshold {
       filter          = "metric.type=\"compute.googleapis.com/instance/cpu/utilization\" resource.type=\"gce_instance\""
-      duration        = "900s"
+      duration        = "${var.cpu_high_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 0.9
+      threshold_value = "${var.cpu_high_threshold / 100.0}"
 
       trigger {
         count = 1
@@ -147,7 +147,7 @@ resource "google_monitoring_alert_policy" "cpu_90" {
 
 resource "google_monitoring_alert_policy" "cpu_80" {
   project      = "${var.gce_project}"
-  display_name = "CPU over 80%"
+  display_name = "CPU over ${var.cpu_medium_threshold}%"
   combiner     = "OR"
 
   conditions {
@@ -155,9 +155,9 @@ resource "google_monitoring_alert_policy" "cpu_80" {
 
     condition_threshold {
       filter          = "metric.type=\"compute.googleapis.com/instance/cpu/utilization\" resource.type=\"gce_instance\""
-      duration        = "3600s"
+      duration        = "${var.cpu_medium_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 0.8
+      threshold_value = "${var.cpu_medium_threshold / 100.0}"
 
       trigger {
         count = 1
@@ -180,7 +180,7 @@ resource "google_monitoring_alert_policy" "cpu_80" {
 
 resource "google_monitoring_alert_policy" "cpu_50" {
   project      = "${var.gce_project}"
-  display_name = "CPU over 50%"
+  display_name = "CPU over ${var.cpu_low_threshold}%"
   combiner     = "OR"
 
   conditions {
@@ -188,9 +188,9 @@ resource "google_monitoring_alert_policy" "cpu_50" {
 
     condition_threshold {
       filter          = "metric.type=\"compute.googleapis.com/instance/cpu/utilization\" resource.type=\"gce_instance\""
-      duration        = "21600s"
+      duration        = "${var.cpu_low_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 0.5
+      threshold_value = "${var.cpu_low_threshold / 100.0}"
 
       trigger {
         count = 1
@@ -213,7 +213,7 @@ resource "google_monitoring_alert_policy" "cpu_50" {
 
 resource "google_monitoring_alert_policy" "memory_90" {
   project      = "${var.gce_project}"
-  display_name = "Memory over 90%"
+  display_name = "Memory over ${var.memory_threshold}%"
   combiner     = "OR"
 
   conditions {
@@ -221,9 +221,9 @@ resource "google_monitoring_alert_policy" "memory_90" {
 
     condition_threshold {
       filter          = "metric.type=\"agent.googleapis.com/memory/percent_used\" resource.type=\"gce_instance\""
-      duration        = "900s"
+      duration        = "${var.memory_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 90
+      threshold_value = "${var.memory_threshold}"
 
       trigger {
         count = 1
@@ -254,9 +254,9 @@ resource "google_monitoring_alert_policy" "slow_disk_io" {
 
     condition_threshold {
       filter          = "metric.type=\"agent.googleapis.com/disk/io_time\" resource.type=\"gce_instance\""
-      duration        = "900s"
+      duration        = "${var.disk_io_latency_duration}"
       comparison      = "COMPARISON_GT"
-      threshold_value = 3
+      threshold_value = "${var.disk_io_latency_threshold}"
 
       trigger {
         count = 1

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -5,3 +5,67 @@ variable "notification_channels" {
   type        = "list"
   default     = []
 }
+
+variable "throttled_write_ops_threshold" {
+  default = "1"
+}
+
+variable "throttled_write_ops_duration" {
+  default = "900s"
+}
+
+variable "disk_usage_threshold" {
+  default = "90"
+}
+
+variable "disk_usage_duration" {
+  default = "3600s"
+}
+
+variable "disk_operations_threshold" {
+  default = "4"
+}
+
+variable "disk_operations_duration" {
+  default = "900s"
+}
+
+variable "cpu_high_threshold" {
+  default = "90"
+}
+
+variable "cpu_high_duration" {
+  default = "900s"
+}
+
+variable "cpu_medium_threshold" {
+  default = "80"
+}
+
+variable "cpu_medium_duration" {
+  default = "3600s"
+}
+
+variable "cpu_low_threshold" {
+  default = "50"
+}
+
+variable "cpu_low_duration" {
+  default = "21600s"
+}
+
+variable "memory_threshold" {
+  default = "90"
+}
+
+variable "memory_duration" {
+  default = "900s"
+}
+
+variable "disk_io_latency_threshold" {
+  default = "3"
+}
+
+variable "disk_io_latency_duration" {
+  default = "900s"
+}


### PR DESCRIPTION
Let us pass through variables for the threshold/duration of all the alerts.