### PR TITLE
exlude unusual devices from disk usage alert

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -69,6 +69,9 @@ This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-1.1.0` - only include `sd.*` devices for disk usage
+  (exlude `loop0`, etc, which can show up as 100% full but not
+  actually indicate a problem)
 * `stackdriver-1.0.0` - terraform 0.12 conversion
 * `stackdriver-0.3.0` - add runbook links for every alert
 * `stackdriver-0.2.0` - parameterize threshold/duration for all alerts

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -50,7 +50,7 @@ resource "google_monitoring_alert_policy" "disk_usage_90" {
     display_name = "GCE VM Instance - Disk utilization for used"
 
     condition_threshold {
-      filter          = "metric.type=\"agent.googleapis.com/disk/percent_used\" resource.type=\"gce_instance\" metric.label.\"state\"=\"used\""
+      filter          = "metric.type=\"agent.googleapis.com/disk/percent_used\" resource.type=\"gce_instance\" metric.label.\"state\"=\"used\" metric.label.\"device\"=monitoring.regex.full_match(\"sd.*\")"
       duration        = var.disk_usage_duration
       comparison      = "COMPARISON_GT"
       threshold_value = var.disk_usage_threshold


### PR DESCRIPTION
Eg, we had a Pagerduty alert because `loop0`, which Ubuntu mounted as `/snap/core/...` was at 100%. That's normal and not a problem. The Stackdriver agent already excludes certain things like `tmpfs` and `udev`, but apparently doesn't know about loop devices.

This commit adds a filter on the device to only devices that match `sd.*` which should match actual filesystem mounts.