### PR TITLE
stackdriver: cloud sql monitoring

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -61,6 +61,16 @@ triggers.
 * `disk_io_latency_threshold` - average latency on disk io. defaults
    to `3`
 * `disk_io_latency_duration` - defaults to `900s`.
+* `cloud_sql_high_cpu_threshold` - defaults to `0.5`
+* `cloud_sql_high_cpu_duration` - defaults to `3600s`
+* `cloud_sql_disk_utilization_threshold` - defaults to `0.9`
+* `cloud_sql_disk_utilization_duration` - defaults to `3600s`
+* `cloud_sql_disk_read_ops_threshold` - defaults to `1`
+* `cloud_sql_disk_read_ops_duration` - defaults to `3600s`
+* `cloud_sql_disk_write_ops_threshold` - defaults to `1`
+* `cloud_sql_disk_write_ops_duration` - defaults to `3600s`
+* `cloud_sql_memory_utilization_threshold` - defaults to `0.8`
+* `cloud_sql_memory_utilization_duration` - defaults to `3600s`
 
 
 ## Outputs
@@ -69,6 +79,7 @@ This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-2.1.0` - add Cloud SQL monitoring (basic CPU, disk, memory utilization)
 * `stackdriver-2.0.0` - require terraform 1.0.0
 * `stackdriver-1.1.2` - fix a 0.12 warning about interpolation-only expressions
 * `stackdriver-1.1.1` - fix a 0.12 warning about type constraints

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -67,7 +67,7 @@ triggers.
 * `cloud_sql_disk_utilization_duration` - defaults to `3600s`
 * `cloud_sql_disk_read_ops_threshold` - defaults to `1`
 * `cloud_sql_disk_read_ops_duration` - defaults to `3600s`
-* `cloud_sql_disk_write_ops_threshold` - defaults to `1`
+* `cloud_sql_disk_write_ops_threshold` - defaults to `100`
 * `cloud_sql_disk_write_ops_duration` - defaults to `3600s`
 * `cloud_sql_memory_utilization_threshold` - defaults to `0.8`
 * `cloud_sql_memory_utilization_duration` - defaults to `3600s`
@@ -79,6 +79,7 @@ This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-2.1.1` - adjust Cloud SQL write ops threshold
 * `stackdriver-2.1.0` - add Cloud SQL monitoring (basic CPU, disk, memory utilization)
 * `stackdriver-2.0.0` - require terraform 1.0.0
 * `stackdriver-1.1.2` - fix a 0.12 warning about interpolation-only expressions

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -306,3 +306,196 @@ resource "google_monitoring_alert_policy" "slow_disk_io" {
 
   notification_channels = var.notification_channels
 }
+
+resource "google_monitoring_alert_policy" "cloudsql_cpu_utilization" {
+  project      = var.gce_project
+  display_name = "Cloud SQL CPU Utilization High"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL Database - CPU utilization [MEAN]"
+
+    condition_threshold {
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/cpu/utilization\" resource.type=\"cloudsql_database\""
+      duration        = var.cloud_sql_high_cpu_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.cloud_sql_high_cpu_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_MEAN"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1942094026/ALERT+Cloud+SQL+CPU+Utilization+High)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "cloudsql_disk_utilization" {
+  project      = var.gce_project
+  display_name = "Cloud SQL Disk Utilization High"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL Disk utilization"
+
+    condition_threshold {
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/disk/utilization\" resource.type=\"cloudsql_database\""
+      duration        = var.cloud_sql_disk_utilization_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.cloud_sql_disk_utilization_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_MEAN"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1938555602/ALERT+Cloud+SQL+Disk+Utilization+High)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "cloudsql_disk_read_ops" {
+  project      = var.gce_project
+  display_name = "Cloud SQL Disk Read Ops High"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL Disk Read Ops"
+
+    condition_threshold {
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/disk/read_ops_count\" resource.type=\"cloudsql_database\""
+      duration        = var.cloud_sql_disk_read_ops_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.cloud_sql_disk_read_ops_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1943502879/ALERT+Cloud+SQL+Disk+Read+Ops+High)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "cloudsql_disk_write_ops" {
+  project      = var.gce_project
+  display_name = "Cloud SQL Disk Write Ops High"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL Disk Write Ops"
+
+    condition_threshold {
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/disk/write_ops_count\" resource.type=\"cloudsql_database\""
+      duration        = var.cloud_sql_disk_write_ops_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.cloud_sql_disk_write_ops_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1943502879/ALERT+Cloud+SQL+Disk+Write+Ops+High)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "cloudsql_memory_utilization" {
+  project      = var.gce_project
+  display_name = "Cloud SQL Memory Utilization High"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL Memory Utilization"
+
+    condition_threshold {
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/memory/utilization\" resource.type=\"cloudsql_database\""
+      duration        = var.cloud_sql_memory_utilization_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.cloud_sql_memory_utilization_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_MEAN"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1938850392/ALERT+Cloud+SQL+Memory+Utilization+High)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -99,7 +99,7 @@ variable "cloud_sql_disk_write_ops_duration" {
 }
 
 variable "cloud_sql_disk_write_ops_threshold" {
-  default = "1"
+  default = "100"
 }
 
 variable "cloud_sql_memory_utilization_duration" {

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -69,3 +69,44 @@ variable "disk_io_latency_threshold" {
 variable "disk_io_latency_duration" {
   default = "900s"
 }
+
+variable "cloud_sql_high_cpu_duration" {
+  default = "3600s"
+}
+
+variable "cloud_sql_high_cpu_threshold" {
+  default = "0.5"
+}
+
+variable "cloud_sql_disk_utilization_duration" {
+  default = "3600s"
+}
+
+variable "cloud_sql_disk_utilization_threshold" {
+  default = "0.9"
+}
+
+variable "cloud_sql_disk_read_ops_duration" {
+  default = "3600s"
+}
+
+variable "cloud_sql_disk_read_ops_threshold" {
+  default = "1"
+}
+
+variable "cloud_sql_disk_write_ops_duration" {
+  default = "3600s"
+}
+
+variable "cloud_sql_disk_write_ops_threshold" {
+  default = "1"
+}
+
+variable "cloud_sql_memory_utilization_duration" {
+  default = "3600s"
+}
+
+variable "cloud_sql_memory_utilization_threshold" {
+  default = "0.8"
+}
+


### PR DESCRIPTION
Per Vanta recommendations. Adds stackdriver alerts for Cloud SQL CPU utilization, disk utilization, read/write ops, and memory utilization. The defaults are on the high side and mostly educated guesses about what's reasonable. Since we previously had no monitoring of those metrics, it should still be an improvement and we can tighten them up per-project once we have some experience to inform us if they're overly noisy or not.