### PR TITLE
Pagerduty sns terraform 1.0.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,9 +20,12 @@ jobs:
     - name: terraform-fmt health_check
       run:
         terraform fmt health_check
-    - name: terraform-fmt pagerduty_sns
-      run:
-        terraform fmt pagerduty_sns
     - name: terraform-fmt video_bucket
       run:
         terraform fmt video_bucket
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.0.0
+    - name: terraform-fmt pagerduty_sns
+      run:
+        terraform fmt pagerduty_sns

--- a/health_check/main.tf
+++ b/health_check/main.tf
@@ -8,7 +8,7 @@ resource "aws_route53_health_check" "check" {
 
   regions = "${var.regions}"
 
-  tags {
+  tags = {
     Name      = "tf-${var.name}-health-check"
     Terraform = true
   }
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
 
   statistic = "Minimum"
 
-  dimensions {
+  dimensions = {
     HealthCheckId = "${aws_route53_health_check.check.id}"
   }
 

--- a/pagerduty_sns/.terraform.lock.hcl
+++ b/pagerduty_sns/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.45.0"
+  hashes = [
+    "h1:LKU/xfna87/p+hl5yTTW3dvOqWJp5JEM+Dt3nnvSDvA=",
+    "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
+    "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
+    "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
+    "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
+    "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
+    "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
+    "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
+    "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
+    "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
+    "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
+    "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
+  ]
+}

--- a/pagerduty_sns/README.md
+++ b/pagerduty_sns/README.md
@@ -33,3 +33,7 @@ topic_arn = "arn:..."
 
 * `arn` - the ARN of the SNS topic. This is typically needed for
   connecting it to an alarm.
+
+## Releases
+
+* `pagerduty-sns-1.0.0` - Terraform 1.0.0 support

--- a/pagerduty_sns/main.tf
+++ b/pagerduty_sns/main.tf
@@ -1,10 +1,10 @@
 resource "aws_sns_topic" "topic" {
-  name = "${var.name}"
+  name = var.name
 }
 
 resource "aws_sns_topic_subscription" "subscription" {
-  topic_arn              = "${aws_sns_topic.topic.arn}"
+  topic_arn              = aws_sns_topic.topic.arn
   protocol               = "https"
-  endpoint               = "${var.pagerduty_integration_url}"
+  endpoint               = var.pagerduty_integration_url
   endpoint_auto_confirms = true
 }

--- a/pagerduty_sns/versions.tf
+++ b/pagerduty_sns/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }

--- a/pagerduty_sns/versions.tf
+++ b/pagerduty_sns/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.15"
+  required_version = ">= 1.0.0"
 }

--- a/pagerduty_sns/versions.tf
+++ b/pagerduty_sns/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/pagerduty_sns/versions.tf
+++ b/pagerduty_sns/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
update `pagerduty-sns` module for Terraform 1.0.0