### PR TITLE
stackdriver: use terraform 1.0.0 for fmt check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,6 @@ jobs:
     - name: terraform-fmt gcp_project
       run:
         terraform fmt gcp_project
-    - name: terraform-fmt stackdriver
-      run:
-        terraform fmt stackdriver
     - uses: hashicorp/setup-terraform@v1
       with:
         terraform_version: 0.11.14
@@ -26,3 +23,9 @@ jobs:
     - name: terraform-fmt video_bucket
       run:
         terraform fmt video_bucket
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.0.0
+    - name: terraform-fmt stackdriver
+      run:
+        terraform fmt stackdriver


### PR DESCRIPTION
Use terraform 1.0.0 for the `terraform fmt` github actions check on stackdriver.