### PR TITLE
Stackdriver nosql pubsub alerts

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -75,6 +75,8 @@ triggers.
 * `pubsub_message_age_duration` - defaults to `3600s`
 * `datastore_high_reads_threshold` - defaults to `50000`
 * `datastore_high_reads_duration` - defaults to `3600s`
+* `datastore_high_writes_threshold` - defaults to `20000`
+* `datastore_high_writes_duration` - defaults to `3600s`
 
 ## Outputs
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -71,7 +71,8 @@ triggers.
 * `cloud_sql_disk_write_ops_duration` - defaults to `3600s`
 * `cloud_sql_memory_utilization_threshold` - defaults to `0.8`
 * `cloud_sql_memory_utilization_duration` - defaults to `3600s`
-
+* `pubsub_message_age_threshold` - defaults to `10` (seconds)
+* `pubsub_message_age_duration` - defaults to `3600s`
 
 ## Outputs
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -84,6 +84,7 @@ This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-2.2.0` - Pub/Sub and Datastore alerts
 * `stackdriver-2.1.1` - adjust Cloud SQL write ops threshold
 * `stackdriver-2.1.0` - add Cloud SQL monitoring (basic CPU, disk, memory utilization)
 * `stackdriver-2.0.0` - require terraform 1.0.0

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -73,6 +73,8 @@ triggers.
 * `cloud_sql_memory_utilization_duration` - defaults to `3600s`
 * `pubsub_message_age_threshold` - defaults to `10` (seconds)
 * `pubsub_message_age_duration` - defaults to `3600s`
+* `datastore_high_reads_threshold` - defaults to `50000`
+* `datastore_high_reads_duration` - defaults to `3600s`
 
 ## Outputs
 

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -548,7 +548,7 @@ resource "google_monitoring_alert_policy" "datastore_high_reads" {
     display_name = "Sizes of read entities [COUNT]"
 
     condition_threshold {
-      filter          = "metric.type=\"datastore.googleapis.com/entity/read_sizes\" resource.type=\"datastore_request\"",
+      filter          = "metric.type=\"datastore.googleapis.com/entity/read_sizes\" resource.type=\"datastore_request\""
       duration        = var.datastore_high_reads_duration
       comparison      = "COMPARISON_GT"
 
@@ -588,7 +588,7 @@ resource "google_monitoring_alert_policy" "datastore_high_writes" {
     display_name = "Sizes of write entities [COUNT]"
 
     condition_threshold {
-      filter          = "metric.type=\"datastore.googleapis.com/entity/write_sizes\" resource.type=\"datastore_request\"",
+      filter          = "metric.type=\"datastore.googleapis.com/entity/write_sizes\" resource.type=\"datastore_request\""
       duration        = var.datastore_high_writes_duration
       comparison      = "COMPARISON_GT"
 

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -512,6 +512,7 @@ resource "google_monitoring_alert_policy" "pubsub_message_age" {
       filter          = "metric.type=\"pubsub.googleapis.com/subscription/oldest_unacked_message_age\" resource.type=\"pubsub_subscription\""
       duration        = var.pubsub_message_age_duration
       comparison      = "COMPARISON_GT"
+
       threshold_value = var.pubsub_message_age_threshold
 
       trigger {
@@ -527,6 +528,46 @@ resource "google_monitoring_alert_policy" "pubsub_message_age" {
 
   documentation {
     content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1957920775/ALERT+Pub+Sub+Message+Age)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "datastore_high_reads" {
+  project      = var.gce_project
+  display_name = "Datastore High Reads"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Sizes of read entities [COUNT]"
+
+    condition_threshold {
+      filter          = "metric.type=\"datastore.googleapis.com/entity/read_sizes\" resource.type=\"datastore_request\"",
+      duration        = var.datastore_high_reads_duration
+      comparison      = "COMPARISON_GT"
+
+      threshold_value = var.datastore_high_reads_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+	per_series_aligner   = "ALIGN_DELTA"
+	cross_series_reducer = "REDUCE_COUNT"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1957363885/ALERT+Datastore+High+Reads)"
     mime_type = "text/markdown"
   }
 

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -499,3 +499,41 @@ resource "google_monitoring_alert_policy" "cloudsql_memory_utilization" {
 
   notification_channels = var.notification_channels
 }
+
+resource "google_monitoring_alert_policy" "pubsub_message_age" {
+  project      = var.gce_project
+  display_name = "Pub/Sub Message Age"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud Pub/Sub Subscription - Oldest unacked message age [MEAN]"
+
+    condition_threshold {
+      filter          = "metric.type=\"pubsub.googleapis.com/subscription/oldest_unacked_message_age\" resource.type=\"pubsub_subscription\""
+      duration        = var.pubsub_message_age_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.pubsub_message_age_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1957920775/ALERT+Pub+Sub+Message+Age)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -578,3 +578,43 @@ resource "google_monitoring_alert_policy" "datastore_high_reads" {
 
   notification_channels = var.notification_channels
 }
+
+resource "google_monitoring_alert_policy" "datastore_high_writes" {
+  project      = var.gce_project
+  display_name = "Datastore High Writes"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Sizes of write entities [COUNT]"
+
+    condition_threshold {
+      filter          = "metric.type=\"datastore.googleapis.com/entity/write_sizes\" resource.type=\"datastore_request\"",
+      duration        = var.datastore_high_writes_duration
+      comparison      = "COMPARISON_GT"
+
+      threshold_value = var.datastore_high_writes_threshold
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period     = "300s"
+	per_series_aligner   = "ALIGN_DELTA"
+	cross_series_reducer = "REDUCE_COUNT"
+      }
+    }
+  }
+
+  documentation {
+    content   = "[runbook](https://appsembler.atlassian.net/wiki/spaces/ED/pages/1954808090/ALERT+Datastore+Writes)"
+    mime_type = "text/markdown"
+  }
+
+  # we just use this label to make it clear that this is a Terraform managed resource
+  user_labels = {
+    terraform = true
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -125,3 +125,11 @@ variable "datastore_high_reads_threshold" {
 variable "datastore_high_reads_duration" {
   default = "3600s"
 }
+
+variable "datastore_high_writes_threshold" {
+  default = "20000"
+}
+
+variable "datastore_high_writes_duration" {
+  default = "3600s"
+}

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -110,3 +110,10 @@ variable "cloud_sql_memory_utilization_threshold" {
   default = "0.8"
 }
 
+variable "pubsub_message_age_duration" {
+  default = "3600s"
+}
+
+variable "pubsub_message_age_threshold" {
+  default = "10"
+}

--- a/stackdriver/variables.tf
+++ b/stackdriver/variables.tf
@@ -117,3 +117,11 @@ variable "pubsub_message_age_duration" {
 variable "pubsub_message_age_threshold" {
   default = "10"
 }
+
+variable "datastore_high_reads_threshold" {
+  default = "50000"
+}
+
+variable "datastore_high_reads_duration" {
+  default = "3600s"
+}


### PR DESCRIPTION
More Vanta required alerts. This time on Pub/Sub and Cloud Datastore.

These ones are a bit annoying because we don't really directly use either of those (yet, at least). But if you set up a Cloud Function or GAE application, GCP creates some pub/sub and datastore instances that it uses internally (tracking which version of your app is deployed, etc.) At least in the current setup, these alerts are pretty meaningless for us, but Vanta sees the resources and wants us to have monitoring on them, so here we are.