### PR TITLE
support folder_id on gcp_project

### DIFF
--- a/gcp_project/README.md
+++ b/gcp_project/README.md
@@ -40,6 +40,12 @@ we will consider auto-generating this.
   list --project <yourproject>` will give the list of currently
   enabled ones.
 * `labels` - (Optional) A set of key/value label pairs to assign to the project.
+* `org_id` - (Optional) defaults to the `noderabbit.com` org numerical id. 
+* `folder_id` - (Optional) id of a folder to place project
+  into. Usually this will be a reference to a resource like
+  `google_folder.infrastructure.name`. Defaults to `null`. If you you
+  set this parameter, you **must** also set `org_id = null`. GCP won't
+  allow both to be set.
 
 ## Outputs
 
@@ -49,6 +55,7 @@ we will consider auto-generating this.
 
 ## Releases
 
+* `gcp_project-1.1.0` - add `folder_id` parameter to allow support placing projects in folders.
 * `gcp_project-1.0.0` - Terraform 1.0.0 support
 * `gcp_project-0.9.0` - no longer need google-beta provider
 * `gcp_project-0.8.1` - OS login integrated

--- a/gcp_project/project.tf
+++ b/gcp_project/project.tf
@@ -2,6 +2,7 @@ resource "google_project" "project" {
   name            = var.name
   project_id      = var.project_id
   org_id          = var.org_id
+  folder_id       = var.folder_id
   billing_account = var.billing_account
   labels          = var.labels
 }

--- a/gcp_project/variables.tf
+++ b/gcp_project/variables.tf
@@ -5,7 +5,13 @@ variable "project_id" {
 }
 
 variable "org_id" {
-  default = "508326437899"
+  type = number
+  default = 508326437899
+}
+
+variable "folder_id" {
+  type = string
+  default = null
 }
 
 variable "billing_account" {


### PR DESCRIPTION
This allows us to create and manage projects within a folder, which is a direction I want us to move to simplify some of our IAM and security setup.

`folder_id` defaults to `null`, so it should be backwards compatible with existing projects that aren't in folders. The `google_project` resource requires that one and only one of `org_id` and `folder_id` be set to a value and the other must be `null`. I can't really think of a better way to handle that than to require that if one passes a value for `folder_id`, you must also pass `org_id = null` and to document that in the README.