### PR TITLE
exclude 'free' memory from the high memory alert

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -84,6 +84,7 @@ This module does not produce any outputs.
 
 ## Releases
 
+* `stackdriver-2.2.2` - exclude "free" memory from the high memory usage alert
 * `stackdriver-2.2.1` - syntax error fix
 * `stackdriver-2.2.0` - Pub/Sub and Datastore alerts
 * `stackdriver-2.1.1` - adjust Cloud SQL write ops threshold

--- a/stackdriver/alert_policies.tf
+++ b/stackdriver/alert_policies.tf
@@ -240,7 +240,7 @@ resource "google_monitoring_alert_policy" "memory_90" {
     display_name = "GCE VM Instance - Memory utilization"
 
     condition_threshold {
-      filter          = "metric.type=\"agent.googleapis.com/memory/percent_used\" resource.type=\"gce_instance\""
+      filter          = "metric.type=\"agent.googleapis.com/memory/percent_used\" resource.type=\"gce_instance\" metric.label.\"state\"!=\"free\""
       duration        = var.memory_duration
       comparison      = "COMPARISON_GT"
       threshold_value = var.memory_threshold


### PR DESCRIPTION
An instance with more than 90% of its memory in the "free" state is not something we want to alert on. Exclude state=free from the alert condition.