### PR TITLE
add default CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# see: https://appsembler.atlassian.net/wiki/spaces/ED/pages/2227503161/CODEOWNERS
+* @thraxil


### PR DESCRIPTION
Add a default CODEOWNERS file. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

For now, just set me as the default owner on this repo.