### PR TITLE
enable vanta required services by default

### DIFF
--- a/gcp_project/README.md
+++ b/gcp_project/README.md
@@ -55,6 +55,7 @@ we will consider auto-generating this.
 
 ## Releases
 
+* `gcp_project-1.2.0` - enable vanta required services by default
 * `gcp_project-1.1.0` - add `folder_id` parameter to allow support placing projects in folders.
 * `gcp_project-1.0.0` - Terraform 1.0.0 support
 * `gcp_project-0.9.0` - no longer need google-beta provider

--- a/gcp_project/services.tf
+++ b/gcp_project/services.tf
@@ -7,3 +7,70 @@ resource "google_project_service" "service" {
   disable_on_destroy         = false
 }
 
+# vanta requires a bunch of services to be enabled on every project
+# we just enable them all here so we don't have to keep specifying
+# them in the parameters every time and so they aren't accidently
+# omitted.
+
+resource "google_project_service" "bigtableadmin_service" {
+  project                    = var.project_id
+  service                    = "bigtableadmin.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "bigquery_service" {
+  project                    = var.project_id
+  service                    = "bigquery.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "cloudresourcemanager_service" {
+  project                    = var.project_id
+  service                    = "cloudresourcemanager.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "firestore_service" {
+  project                    = var.project_id
+  service                    = "firestore.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "iam_service" {
+  project                    = var.project_id
+  service                    = "iam.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "monitoring_service" {
+  project                    = var.project_id
+  service                    = "monitoring.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "serviceusage_service" {
+  project                    = var.project_id
+  service                    = "serviceusage.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "spanner_service" {
+  project                    = var.project_id
+  service                    = "spanner.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "sqladmin_service" {
+  project                    = var.project_id
+  service                    = "sqladmin.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}

--- a/gcp_project/variables.tf
+++ b/gcp_project/variables.tf
@@ -5,12 +5,12 @@ variable "project_id" {
 }
 
 variable "org_id" {
-  type = number
+  type    = number
   default = 508326437899
 }
 
 variable "folder_id" {
-  type = string
+  type    = string
   default = null
 }
 


### PR DESCRIPTION
There are a standard set of services that have to be enabled on every project for the Vanta scanning to work. When we first started using them, we were in a rush, so we just added those services to the config for every project. Looking at https://github.com/appsembler/infrastructure/blob/master/gcp_projects/main.tf and searching for "required by Vanta" will demonstrate what I mean.

This PR basically hard-codes those services into the module so we don't have to individually add them to the parameters every single time.
