### PR TITLE
gcp-project: enable VM Manager

### DIFF
--- a/gcp_project/README.md
+++ b/gcp_project/README.md
@@ -55,6 +55,7 @@ we will consider auto-generating this.
 
 ## Releases
 
+* `gcp_project-1.3.0` - enable VM Manager / OS Config by default
 * `gcp_project-1.2.0` - enable vanta required services by default
 * `gcp_project-1.1.0` - add `folder_id` parameter to allow support placing projects in folders.
 * `gcp_project-1.0.0` - Terraform 1.0.0 support

--- a/gcp_project/vm_manager.tf
+++ b/gcp_project/vm_manager.tf
@@ -1,0 +1,44 @@
+# these services are required for VM Manager, which we want to
+# enable on all projects.
+
+resource "google_project_service" "compute_service" {
+  project                    = var.project_id
+  service                    = "compute.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "containeranalysis_service" {
+  project                    = var.project_id
+  service                    = "containeranalysis.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "osconfig_service" {
+  project                    = var.project_id
+  service                    = "osconfig.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "oslogin_service" {
+  project                    = var.project_id
+  service                    = "oslogin.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+# and we need to set some project metadata to actually enable it
+
+resource "google_compute_project_metadata_item" "guestattributes" {
+  project = var.project_id
+  key     = "enable-guest-attributes"
+  value   = "TRUE"
+}
+
+resource "google_compute_project_metadata_item" "osconfig" {
+  project = var.project_id
+  key     = "enable-osconfig"
+  value   = "TRUE"
+}


### PR DESCRIPTION
See:
https://appsembler.atlassian.net/wiki/spaces/ORANGE/blog/2022/03/17/2459926695/VM+Manager+quick+demo

This will be handy for vulnerability/patch management and should be enabled on all of our projects. (Not every VM will immediately work though; the setup also requires that VMs have service agents associated with them and not all of our existing ones do, but this will let us start working through them and make sure that it's all set up for new infrastructure).

To work out what was needed for this, I created a fresh test project and kept track of exactly which services and attributes had to be enabled before I could start up an instance and have it work with VM Manager, so this should be a pretty minimal set of changes.
